### PR TITLE
get code samples from example source code

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd ${DIR}/intro/samples/minifinder
+r2c --debug test 
+cd ${DIR}/intro/samples/minifinder2
+r2c --debug test 
+
+echo 'all tests have succeeded!'

--- a/docs/intro/running.rst
+++ b/docs/intro/running.rst
@@ -17,52 +17,10 @@ Now we can run our analyzer::
 
 We get the following output:
 
-.. code-block:: json
-                
-   {
-     "results": [
-       {
-         "check_id": "whitespace",
-         "path": "perf/O(n).js",
-         "extra": {
-           "whitespace": 77,
-           "total": 241
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "perf/perf.js",
-         "extra": {
-           "whitespace": 213,
-           "total": 1442
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "perf/es6Repeat.js",
-         "extra": {
-           "whitespace": 61,
-           "total": 216
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "test.js",
-         "extra": {
-           "whitespace": 714,
-           "total": 4005
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "index.js",
-         "extra": {
-           "whitespace": 436,
-           "total": 1469
-         }
-       }
-     ]
-   }
+.. literalinclude:: samples/minifinder/examples/leftpad.json
+    :linenos:
+    :language: json
+    :lines: 5-44
 
 This is helpful! We don't see any minified files, but it'd be nice to understand what *percentage* of the file is whitespace. Let's add a percentage field; we can compute this using the program ``bc``. First, we'll add the program to our Dockerfile:
 
@@ -87,58 +45,9 @@ And run again:
 
   $ r2c run --code ~/test-repos/left-pad/
 
-
-
-.. code-block:: json
-   
-   {
-     "results": [
-       {
-         "check_id": "whitespace",
-         "path": "perf/O(n).js",
-         "extra": {
-           "whitespace": 77,
-           "total": 241,
-           "percentage": 31.95
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "perf/perf.js",
-         "extra": {
-           "whitespace": 213,
-           "total": 1442,
-           "percentage": 14.77
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "perf/es6Repeat.js",
-         "extra": {
-           "whitespace": 61,
-           "total": 216,
-           "percentage": 28.24
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "test.js",
-         "extra": {
-           "whitespace": 714,
-           "total": 4005,
-           "percentage": 17.82
-         }
-       },
-       {
-         "check_id": "whitespace",
-         "path": "index.js",
-         "extra": {
-           "whitespace": 436,
-           "total": 1469,
-           "percentage": 29.68
-         }
-       }
-     ]
-   }
+.. literalinclude:: samples/minifinder2/examples/leftpad.json
+    :linenos:
+    :language: json
+    :lines: 5-49
 
 Cool! Now we can hunt for minified files. All of these files look reasonable; though we don't know exactly what our threshold should be, minified files will probably be less than 5 to 10 percent whitespace. To find minified files in top projects and get a sense of what cut-off point to use, we'll want to run this analyzer at scale against npm packages - perhaps the top 1000 to start. To get started, head on over to :doc:`uploading`.

--- a/docs/intro/running.rst
+++ b/docs/intro/running.rst
@@ -65,35 +65,20 @@ We get the following output:
 
 This is helpful! We don't see any minified files, but it'd be nice to understand what *percentage* of the file is whitespace. Let's add a percentage field; we can compute this using the program ``bc``. First, we'll add the program to our Dockerfile:
 
-.. code-block:: Dockerfile
-   :emphasize-lines: 3
-
-   FROM ubuntu:17.10
-                
-   RUN apt update && apt install -y jq gawk bc
-
-   RUN groupadd -r analysis && useradd --no-log-init --system --gid analysis analysis
+.. literalinclude:: samples/minifinder/Dockerfile
+    :linenos:
+    :language: dockerfile
+    :emphasize-lines: 3
+    :lines: 1-5
 
 Now let's add the percentage computation to our whitespace function:
 
-.. code-block:: bash
-   :emphasize-lines: 4,10,11
-                     
-   whitespace () {
-       num_ws=$(gawk -v RS='[[:space:]]' 'END{print NR}' "$1")
-       total=$(wc -c $1 | cut -d ' ' -f 1)
-       path=$(echo "{$1}" |  cut -c 2-)
-       pct=$(echo "scale = 4; $num_ws / $total * 100" | bc)
-       echo -e "{ \n\
-       \"check_id\": \"whitespace\", \n\
-       \"path\": \"${path}\", \n\
-       \"extra\": { \n\
-         \"whitespace\": ${num_ws}, \n\
-         \"total\": ${total}, \n\
-         \"percentage\": ${pct} \n\
-         } \n\
-       }"
-   }
+.. literalinclude:: samples/minifinder/src/analyze.sh
+    :linenos:
+    :language: bash
+    :emphasize-lines: 3,9,10
+    :lines: 6-20
+    
                                 
 And run again:
 

--- a/docs/intro/running.rst
+++ b/docs/intro/running.rst
@@ -9,6 +9,7 @@ Let's test our analyzer! First we'll need a target javascript project to test it
 
   $ mkdir ~/test-repos
   $ git clone https://github.com/stevemao/left-pad ~/test-repos/left-pad
+  $ git checkout v1.3.0
 
 Now we can run our analyzer::
 

--- a/docs/intro/samples/minifinder/Dockerfile
+++ b/docs/intro/samples/minifinder/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:17.10
+
+RUN apt update && apt install -y jq gawk
+
+RUN groupadd -r analysis && useradd --no-log-init --system --gid analysis analysis
+USER analysis
+
+COPY --chown=analysis:analysis src /analyzer
+WORKDIR /
+CMD ["/analyzer/analyze.sh"]

--- a/docs/intro/samples/minifinder/analyzer.json
+++ b/docs/intro/samples/minifinder/analyzer.json
@@ -1,0 +1,11 @@
+{
+    "analyzer_name": "dev/minifinder",
+    "version": "0.0.1",
+    "spec_version": "1.0.0",
+    "dependencies": {
+        "public/source-code": "*"
+    },
+    "type": "commit",
+    "output": "json",
+    "deterministic": true
+}

--- a/docs/intro/samples/minifinder/analyzer.json
+++ b/docs/intro/samples/minifinder/analyzer.json
@@ -1,5 +1,5 @@
 {
-    "analyzer_name": "dev/minifinder",
+    "analyzer_name": "YOUR-ORGANIZATION-HERE/minifinder",
     "version": "0.0.1",
     "spec_version": "1.0.0",
     "dependencies": {

--- a/docs/intro/samples/minifinder/examples/leftpad.json
+++ b/docs/intro/samples/minifinder/examples/leftpad.json
@@ -1,0 +1,47 @@
+{
+    "target": "https://github.com/stevemao/left-pad",
+    "target_hash": "v1.3.0",
+    "expected": [
+      {
+        "check_id": "whitespace",
+        "path": "test.js",
+        "extra": {
+          "whitespace": 714,
+          "total": 4005
+        }
+      },
+      {
+        "check_id": "whitespace",
+        "path": "index.js",
+        "extra": {
+          "whitespace": 436,
+          "total": 1469
+        }
+      },
+      {
+        "check_id": "whitespace",
+        "path": "perf/O(n).js",
+        "extra": {
+          "whitespace": 77,
+          "total": 241
+        }
+      },
+      {
+        "check_id": "whitespace",
+        "path": "perf/perf.js",
+        "extra": {
+          "whitespace": 213,
+          "total": 1442
+        }
+      },
+      {
+        "check_id": "whitespace",
+        "path": "perf/es6Repeat.js",
+        "extra": {
+          "whitespace": 61,
+          "total": 216
+        }
+      }
+    ]
+  }
+  

--- a/docs/intro/samples/minifinder/src/analyze.sh
+++ b/docs/intro/samples/minifinder/src/analyze.sh
@@ -6,7 +6,7 @@ CODE_DIR="/analysis/inputs/public/source-code"
 whitespace () {
     num_ws=$(gawk -v RS='[[:space:]]' 'END{print NR}' "$1")
     total=$(wc -c $1 | cut -d ' ' -f 1)
-    path=$(echo "{$1}" |  cut -c 2-)
+    path=$(echo $1 | cut -c 3-)
     echo -e "{ \n\
     \"check_id\": \"whitespace\", \n\
     \"path\": \"${path}\", \n\

--- a/docs/intro/samples/minifinder/src/analyze.sh
+++ b/docs/intro/samples/minifinder/src/analyze.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+CODE_DIR="/analysis/inputs/public/source-code"
+
+whitespace () {
+    num_ws=$(gawk -v RS='[[:space:]]' 'END{print NR}' "$1")
+    total=$(wc -c $1 | cut -d ' ' -f 1)
+    path=$(echo "{$1}" |  cut -c 2-)
+    echo -e "{ \n\
+    \"check_id\": \"whitespace\", \n\
+    \"path\": \"${path}\", \n\
+    \"extra\": { \n\
+      \"whitespace\": ${num_ws}, \n\
+      \"total\": ${total} \n\
+      } \n\
+    }"
+}
+
+export -f whitespace
+
+cd ${CODE_DIR}
+
+find . -name '*.js' | \
+  xargs -n 1 -I {} bash -c 'whitespace "$@"' _ {} | \
+  jq -s '{results: .}' | \
+  tee /analysis/output/output.json

--- a/docs/intro/samples/minifinder/src/unittest.sh
+++ b/docs/intro/samples/minifinder/src/unittest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "⚠️ Empty unittest!"

--- a/docs/intro/samples/minifinder2/Dockerfile
+++ b/docs/intro/samples/minifinder2/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:17.10
+
+RUN apt update && apt install -y jq gawk bc
+
+RUN groupadd -r analysis && useradd --no-log-init --system --gid analysis analysis
+USER analysis
+
+COPY --chown=analysis:analysis src /analyzer
+WORKDIR /
+CMD ["/analyzer/analyze.sh"]

--- a/docs/intro/samples/minifinder2/analyzer.json
+++ b/docs/intro/samples/minifinder2/analyzer.json
@@ -1,0 +1,11 @@
+{
+    "analyzer_name": "dev/minifinder",
+    "version": "0.0.1",
+    "spec_version": "1.0.0",
+    "dependencies": {
+        "public/source-code": "*"
+    },
+    "type": "commit",
+    "output": "json",
+    "deterministic": true
+}

--- a/docs/intro/samples/minifinder2/analyzer.json
+++ b/docs/intro/samples/minifinder2/analyzer.json
@@ -1,6 +1,6 @@
 {
-    "analyzer_name": "dev/minifinder",
-    "version": "0.0.1",
+    "analyzer_name": "YOUR-ORGANIZATION-HERE/minifinder",
+    "version": "0.0.2",
     "spec_version": "1.0.0",
     "dependencies": {
         "public/source-code": "*"

--- a/docs/intro/samples/minifinder2/examples/leftpad.json
+++ b/docs/intro/samples/minifinder2/examples/leftpad.json
@@ -1,0 +1,52 @@
+{
+    "target": "https://github.com/stevemao/left-pad",
+    "target_hash": "v1.3.0",
+    "expected": [
+        {
+          "check_id": "whitespace",
+          "path": "test.js",
+          "extra": {
+            "whitespace": 714,
+            "total": 4005,
+            "percentage": 17.82
+          }
+        },
+        {
+          "check_id": "whitespace",
+          "path": "index.js",
+          "extra": {
+            "whitespace": 436,
+            "total": 1469,
+            "percentage": 29.68
+          }
+        },
+        {
+          "check_id": "whitespace",
+          "path": "perf/O(n).js",
+          "extra": {
+            "whitespace": 77,
+            "total": 241,
+            "percentage": 31.95
+          }
+        },
+        {
+          "check_id": "whitespace",
+          "path": "perf/perf.js",
+          "extra": {
+            "whitespace": 213,
+            "total": 1442,
+            "percentage": 14.77
+          }
+        },
+        {
+          "check_id": "whitespace",
+          "path": "perf/es6Repeat.js",
+          "extra": {
+            "whitespace": 61,
+            "total": 216,
+            "percentage": 28.24
+          }
+        }
+      ]
+  }
+  

--- a/docs/intro/samples/minifinder2/src/analyze.sh
+++ b/docs/intro/samples/minifinder2/src/analyze.sh
@@ -6,7 +6,7 @@ CODE_DIR="/analysis/inputs/public/source-code"
 whitespace () {
     num_ws=$(gawk -v RS='[[:space:]]' 'END{print NR}' "$1")
     total=$(wc -c $1 | cut -d ' ' -f 1)
-    path=$(echo "{$1}" |  cut -c 2-)
+    path=$(echo $1 | cut -c 3-)
     pct=$(echo "scale = 4; $num_ws / $total * 100" | bc)
     echo -e "{ \n\
     \"check_id\": \"whitespace\", \n\

--- a/docs/intro/samples/minifinder2/src/analyze.sh
+++ b/docs/intro/samples/minifinder2/src/analyze.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+CODE_DIR="/analysis/inputs/public/source-code"
+
+whitespace () {
+    num_ws=$(gawk -v RS='[[:space:]]' 'END{print NR}' "$1")
+    total=$(wc -c $1 | cut -d ' ' -f 1)
+    path=$(echo "{$1}" |  cut -c 2-)
+    pct=$(echo "scale = 4; $num_ws / $total * 100" | bc)
+    echo -e "{ \n\
+    \"check_id\": \"whitespace\", \n\
+    \"path\": \"${path}\", \n\
+    \"extra\": { \n\
+      \"whitespace\": ${num_ws}, \n\
+      \"total\": ${total}, \n\
+      \"percentage\": ${pct} \n\
+      } \n\
+    }"
+}
+
+export -f whitespace
+
+cd ${CODE_DIR}
+
+find . -name '*.js' | \
+  xargs -n 1 -I {} bash -c 'whitespace "$@"' _ {} | \
+  jq -s '{results: .}' | \
+  tee /analysis/output/output.json

--- a/docs/intro/samples/minifinder2/src/unittest.sh
+++ b/docs/intro/samples/minifinder2/src/unittest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "⚠️ Empty unittest!"

--- a/docs/intro/uploading.rst
+++ b/docs/intro/uploading.rst
@@ -8,19 +8,9 @@ go. For larger analyzers, this would be the time to also run all of our unit tes
 tests with ``r2c`` :doc:`/cli/unittest` and ``r2c`` :doc:`/cli/test`. For this tutorial analyzer,
 we'll just sanity-check the fields in ``analyzer.json``:
 
-.. code-block:: json
-
-   {
-       "analyzer_name": "YOUR-ORGANIZATION-HERE/minifinder",
-       "version": "0.0.1",
-       "spec_version": "1.0.0",
-       "dependencies": {
-           "source-code": "*"
-       },
-       "type": "commit",
-       "output": "json",
-       "deterministic": true
-   }            
+.. literalinclude:: samples/minifinder/analyzer.json
+    :linenos:
+    :language: json
    
 Everything looks mostly good. However, to follow best practices, our analyzer should use `Semantic
 Versioning`_. As this is our first release, but we're not yet sure if everything is production

--- a/docs/intro/writing.rst
+++ b/docs/intro/writing.rst
@@ -17,14 +17,12 @@ output as ``r2c``-compliant JSON.
 
 Before we can use these tools, we'll need to install them in our Docker container. Our default base image already includes most of the programs we need, but we'll need to install gawk and jq. To do this, add the following line to the project's Dockerfile:
 
-.. code-block:: dockerfile
-   :emphasize-lines: 3
 
-   FROM ubuntu:17.10
-                
-   RUN apt update && apt install -y jq gawk
-
-   RUN groupadd -r analysis && useradd --no-log-init --system --gid analysis analysis
+.. literalinclude:: samples/minifinder/Dockerfile
+    :linenos:
+    :language: dockerfile
+    :emphasize-lines: 3
+    :lines: 1-5
 
 When we run our code later, the container will automatically be rebuilt.
    
@@ -48,36 +46,9 @@ their data, see :doc:`/api/index`.
 
 To run that command over all files in our input, we can use the ``find`` program. Let's add it into our analyze.sh so that the file looks like this:
 
-.. code-block:: bash
-   :linenos:
-   :emphasize-lines: 6-17,19,21,23-26
-
-   #!/bin/bash
-
-   set -e
-   CODE_DIR="/analysis/inputs/public/source-code"
-
-   whitespace () {
-       num_ws=$(gawk -v RS='[[:space:]]' 'END{print NR}' "$1")
-       total=$(wc -c $1 | cut -d ' ' -f 1)
-       echo -e "{ \n\
-       \"check_id\": \"whitespace\", \n\
-       \"path\": \"$1\", \n\
-       \"extra\": { \n\
-         \"whitespace\": ${num_ws}, \n\
-         \"total\": ${total} \n\
-         } \n\
-       }"
-   }
-
-   export -f whitespace
-
-   cd ${CODE_DIR}
-
-   find . -name '*.js' | \
-     xargs -n 1 -I {} bash -c 'whitespace "$@"' _ {} | \
-     jq -s '{results: .}' | \
-     tee /analysis/output/output.json
+.. literalinclude:: samples/minifinder/src/analyze.sh
+    :linenos:
+    :language: bash
 
 There's a lot going on there, so we'll take it line by line.
 


### PR DESCRIPTION
`./build.sh` will build and run integration tests minifinder v1 and v2, from which the source code in the examples is derived. 

The downside is that it's a little harder while writing the docs to see what line number you're referring to, but IMO this is outweighed by being able to easily test the code samples via scripts and integration steps.