### PR TITLE
Make navbar sticky and add prev/next links, fixes #46

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,8 @@ html_theme = 'alabaster'
 #
 html_theme_options = {
     'description': 'Distributed program analysis for the open-source community',
+    'fixed_sidebar' :'true',
+    'show_relbars': 'true',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
This uses the Alabaster theme config options to make the navbar sticky and add previous and next article links to the header and footer of the page